### PR TITLE
fix: Configure Railway for Python backend deployment

### DIFF
--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -1,0 +1,12 @@
+[phases.setup]
+nixPkgs = ['python39', 'pip']
+
+[phases.install]
+cmds = ['pip install -r requirements.txt']
+
+[phases.build]
+cmds = []
+
+[start]
+cmd = 'uvicorn app.main:app --host 0.0.0.0 --port $PORT'
+

--- a/railway.json
+++ b/railway.json
@@ -1,14 +1,3 @@
 {
-  "$schema": "https://railway.app/railway.schema.json",
-  "build": {
-    "builder": "NIXPACKS",
-    "buildCommand": "cd backend && pip install -r requirements.txt"
-  },
-  "deploy": {
-    "startCommand": "cd backend && uvicorn app.main:app --host 0.0.0.0 --port $PORT",
-    "healthcheckPath": "/health",
-    "healthcheckTimeout": 100,
-    "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
-  }
+  "$schema": "https://railway.app/railway.schema.json"
 }


### PR DESCRIPTION
- Simplify railway.json to avoid build conflicts
- Add nixpacks.toml in backend directory
- Explicitly configure Python 3.9 environment
- Fix pip installation issues
- Set proper start command for uvicorn